### PR TITLE
Add verbosity diag for dotnet-format

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build ./ContainizationStarter.sln -c Release --no-restore
 
     - name: Format Checking
-      run: dotnet format ./ContainizationStarter.sln --no-restore --verify-no-changes
+      run: dotnet format ./ContainizationStarter.sln --no-restore --verify-no-changes -v diag
 
     - name: Test
       run:  dotnet test ./ContainizationStarter.sln -c Release --no-build --verbosity normal


### PR DESCRIPTION
https://github.com/vancodocton/ContainizationStarter/actions/runs/6284359015/job/17065650281 result warning for `dotnet format`.

Set the verbosity option to the 'diagnostic' level to log warnings.