### PR TITLE
Address several docker compose project issues

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,20 +4,20 @@ services:
   webapp:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=https://+:443;http://+:80
+      - ASPNETCORE_URLS=http://+:80
     ports:
       - "8000:80"
-      - "7000:443"
+      # - "7000:443"
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
   webapi:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=https://+:443;http://+:80
+      - ASPNETCORE_URLS=http://+:80
     ports:
       - "8001:80"
-      - "7001:443"
+      # - "7001:443"
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - "sqlserver"
 
   sqlserver:
-    container_name: "MSSQL"
     image: "mcr.microsoft.com/mssql/server:2022-latest"
     shm_size: 1gb
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   webapp:
@@ -30,4 +30,3 @@ services:
 
 volumes:
   mssql22:
-  

--- a/launchSettings.json
+++ b/launchSettings.json
@@ -5,7 +5,8 @@
       "commandVersion": "1.0",
       "serviceActions": {
         "webapp": "StartDebugging",
-        "webapi": "StartDebugging"
+        "webapi": "StartDebugging",
+        "sqlserver": "StartWithoutDebugging"
       }
     }
   }


### PR DESCRIPTION
At e4d2077dc51330fdf90edb45de57403726a7f867, docker-compose cannot run successfully on Linux because HTTPS is enabled for both `WebApi` and `WebApp`. Config HTTPS for Linux is not an easy job, especially for CI servers for automation. The final decision is to disable HTTPS for docker-compose.

Removing hard code name of docker-compose `sqlserver` service that causes conflict in development.

Regenerate lauchSettings for docker-compose.
